### PR TITLE
Use `pdf_document` output only where needed

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -49,9 +49,5 @@ output:
       include:
         after_body: footer.html
       css: style.css
-  pdf_document:
-    toc: true
-    number_sections: true
-    latex_engine: xelatex
 new_session: true
 exclude: ["renv.lock", "raw-data"]

--- a/intro.Rmd
+++ b/intro.Rmd
@@ -2,6 +2,11 @@
 title: "1. Introduction to High Dimensional Data Analysis"
 author: "Lieven Clement"
 date: "statOmics, Ghent University (https://statomics.github.io)"
+output:
+  pdf_document:
+    toc: true
+    number_sections: true
+    latex_engine: xelatex
 ---
 
 # Introduction

--- a/lda.Rmd
+++ b/lda.Rmd
@@ -2,6 +2,11 @@
 title: "Linear Discriminant Analysis (LDA)"
 author: "Lieven Clement"
 date: "statOmics, Ghent University (https://statomics.github.io)"
+output:
+  pdf_document:
+    toc: true
+    number_sections: true
+    latex_engine: xelatex
 ---
 
 ```{r}

--- a/lsi.Rmd
+++ b/lsi.Rmd
@@ -2,6 +2,11 @@
 title: "Large Scale Inference"
 author: "Lieven Clement"
 date: "statOmics, Ghent University (https://statomics.github.io)"
+output:
+  pdf_document:
+    toc: true
+    number_sections: true
+    latex_engine: xelatex
 ---
 
 # Motivation

--- a/prediction.Rmd
+++ b/prediction.Rmd
@@ -2,6 +2,11 @@
 title: "3. Prediction with High Dimensional Predictors"
 author: "Lieven Clement"
 date: "statOmics, Ghent University (https://statomics.github.io)"
+output:
+  pdf_document:
+    toc: true
+    number_sections: true
+    latex_engine: xelatex
 ---
 
 ```{r echo=FALSE, message= FALSE}

--- a/sparseSvd.Rmd
+++ b/sparseSvd.Rmd
@@ -2,6 +2,11 @@
 title: "4. Sparse Singular Value Decomposition"
 author: "Lieven Clement"
 date: "statOmics, Ghent University (https://statomics.github.io)"
+output:
+  pdf_document:
+    toc: true
+    number_sections: true
+    latex_engine: xelatex
 ---
 
 ```{r echo = FALSE, warning = FALSE}

--- a/svd.Rmd
+++ b/svd.Rmd
@@ -2,6 +2,11 @@
 title: "2. Singular Value Decomposition"
 author: "Lieven Clement"
 date: "statOmics, Ghent University (https://statomics.github.io)"
+output:
+  pdf_document:
+    toc: true
+    number_sections: true
+    latex_engine: xelatex
 ---
 
 # Introduction


### PR DESCRIPTION
* Remove `pdf_document` from `output` in `_site.yml`
* Add it to the indvidual Rmd files where needed

Currently there is no way to prevent some Rmd files from compiling to PDF if it's specified in `_site.yml`, which causes unnecessary problems.