### PR TITLE
GHA: fix renv setup

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           cache-version: ${{ env.cache-version }}
 
-      - name: Install packages
-        run: |
-          R -e 'install.packages("renv")'
-          R -e 'renv::restore()'
-
       - name: Session info
         run: |
           install.packages('sessioninfo')


### PR DESCRIPTION
No need to install renv and restore again.
Caching fixed after https://github.com/r-lib/actions/pull/414